### PR TITLE
[types] GeolocationResult

### DIFF
--- a/types/bmapgl/bmapgl.service.d.ts
+++ b/types/bmapgl/bmapgl.service.d.ts
@@ -363,6 +363,16 @@ declare namespace BMapGL {
     interface GeolocationResult {
         point: Point;
         accuracy: number;
+        address: AddressComponent;
+        // https://mapopen-pub-jsapi.bj.bcebos.com/jsapi/reference/jsapi_webgl_1_0.html#a8b41
+        // 以下为实际返回，但文档中不存在
+        latitude: number;
+        longitude: number;
+        altitude: null;
+        altitudeAccuracy: null;
+        heading: null;
+        speed: null;
+        timestamp: null;
     }
     class Boundary {
         constructor();


### PR DESCRIPTION
根据实际返回的示例，补全缺少的属性

```json
{
    "accuracy": 209,
    "altitude": null,
    "altitudeAccuracy": null,
    "heading": null,
    "latitude": 27.1234,
    "longitude": 113.1234,
    "speed": null,
    "timestamp": null,
    "point": {
        "lng": 113.1234,
        "lat": 27.1234
    },
    "address": {
        "country": "",
        "city": "xx市",
        "city_code": 0,
        "district": "xx区",
        "province": "xx省",
        "street": "xx路",
        "street_number": ""
    }
}
```